### PR TITLE
Catch TimezoneError exception

### DIFF
--- a/custom_components/petkit/config_flow.py
+++ b/custom_components/petkit/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from petkitaio.exceptions import AuthError, PetKitError, RegionError, ServerError
+from petkitaio.exceptions import AuthError, PetKitError, RegionError, ServerError, TimezoneError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -67,6 +67,8 @@ class PetKitConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await async_validate_api(self.hass, email, password, region)
             except RegionError:
                 errors["base"] = "region_error"
+            except TimezoneError:
+                errors["base"] = "timezone_error"
             except AuthError:
                 errors["base"] = "invalid_auth"
             except ConnectionError:
@@ -118,6 +120,8 @@ class PetKitConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await async_validate_api(self.hass, email, password, region)
             except RegionError:
                 errors["base"] = "region_error"
+            except TimezoneError:
+                errors["base"] = "timezone_error"
             except AuthError:
                 errors["base"] = "invalid_auth"
             except ConnectionError:

--- a/custom_components/petkit/manifest.json
+++ b/custom_components/petkit/manifest.json
@@ -11,8 +11,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/RobertD502/home-assistant-petkit/issues",
   "requirements": [
-    "petkitaio==0.1.8",
+    "petkitaio==0.1.9",
     "tzlocal>=4.2"
   ],
-  "version": "0.1.8"
+  "version": "0.1.9"
 }

--- a/custom_components/petkit/strings.json
+++ b/custom_components/petkit/strings.json
@@ -26,7 +26,8 @@
       "no_devices": "No devices found on account",
       "server_busy": "PetKit servers are busy. Please try again later.",
       "petkit_error": "Unknown error encountered. Please see Home Assistant logs for more details.",
-      "region_error": "Please select the country associated with your account."
+      "region_error": "Please select the country associated with your account.",
+      "timezone_error": "A timezone could not be found. If you are running Home Assistant as a standalone Docker container, you must define the TZ environmental variable."
     },
     "abort": {
       "already_configured": "PetKit account is already configured",

--- a/custom_components/petkit/translations/en.json
+++ b/custom_components/petkit/translations/en.json
@@ -10,7 +10,8 @@
             "no_devices": "No devices found on account",
             "server_busy": "PetKit servers are busy. Please try again later.",
             "petkit_error": "Unknown error encountered. Please see Home Assistant logs for more details.",
-            "region_error": "Please select the country associated with your account."
+            "region_error": "Please select the country associated with your account.",
+            "timezone_error": "A timezone could not be found. If you are running Home Assistant as a standalone Docker container, you must define the TZ environmental variable."
         },
         "step": {
             "user": {

--- a/custom_components/petkit/translations/hr.json
+++ b/custom_components/petkit/translations/hr.json
@@ -10,7 +10,8 @@
             "no_devices": "Na vašem računu nisu pronađeni uređaji",
             "server_busy": "PetKit serveri su zauzeti. Molimo pokušajte ponovo kasnije.",
             "petkit_error": "Došlo je do nepoznate pogreške. Za više detalja pogledajte Home Assistant zapisnike.",
-            "region_error": "Odaberite državu povezanu s vašim računom."
+            "region_error": "Odaberite državu povezanu s vašim računom.",
+            "timezone_error": "Vremenska zona nije pronađena. Ako pokrećete Home Assistant kao samostalni Docker spremnik, morate definirati TZ varijablu."
         },
         "step": {
             "user": {


### PR DESCRIPTION
Catches the TimezoneError exception introduced in petkitaio 0.1.9 and presents users with an error message (instead of unknown error) reminding docker users that they need to set a TZ environmental variable.