### PR TITLE
Fix: KeyError: 'petName' (same animals weight problem)

### DIFF
--- a/custom_components/petkit/sensor.py
+++ b/custom_components/petkit/sensor.py
@@ -2817,7 +2817,7 @@ class MAXLastEvent(CoordinatorEntity, SensorEntity):
                 return description
 
         if event_type == 10:
-            if (record['petId'] == '-2') or (record['petId'] == '-1'):
+            if record["petId"] in ["-1", "-2", "-3"]:
                 name = 'Unknown'
             else:
                 name = record['petName']


### PR DESCRIPTION
Fix  KeyError: 'petName' in Sensor when record["petId"] goes to "-3"
The code -3 appears when several animals have the same weight and the litter cannot identify them

